### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/src/flexo_syside_lib/committer.py
+++ b/src/flexo_syside_lib/committer.py
@@ -125,7 +125,7 @@ def commit_sysml_to_flexo(
     if verbose:
         print(f"[Flexo] Base URL: {base_url}")
         print(f"[Flexo] Target project: name='{project_name}', id={project_id}")
-        print(f"[Flexo] Using token prefix: {api_key[:10]}...")
+        print("[Flexo] Authentication token is configured.")
 
     # --- Build client ---
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/Open-MBEE/flexo_syside/security/code-scanning/2](https://github.com/Open-MBEE/flexo_syside/security/code-scanning/2)

In general, the problem should be fixed by ensuring that no part of the API key (or any other secret) is written to logs, even partially. Instead of logging a prefix of the token, you can log only non-sensitive metadata, such as whether a token is present, its length, or that authentication has been configured, without including any actual characters from the key itself.

The best targeted fix here is to modify the verbose logging line at line 128 so that it does not include `api_key[:10]` or any other substring of the secret. We can keep the informational value by logging a generic message like “[Flexo] Authentication token configured.” or, if needed, the length of the token (which is usually not sensitive), e.g. `len(api_key)` without printing characters of the secret. This change is confined to `commit_sysml_to_flexo` in `src/flexo_syside_lib/committer.py` and does not alter any functional behavior related to authentication or API calls; it only changes what gets printed when `verbose` is `True`. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
