### PR TITLE
fix libary handling

### DIFF
--- a/src/flexo_syside_lib/serde.py
+++ b/src/flexo_syside_lib/serde.py
@@ -88,16 +88,25 @@ def _write_models_to_temp_paths(
     sysml_models: list[tuple[str, str]],
 ) -> tuple[list[str], list[str]]:
     basenames = [Path(filename).name for filename, _text in sysml_models]
-    if len(set(basenames)) != len(basenames):
-        raise ValueError("sysml_models filenames must be unique after basename normalization")
-
     temp_paths: list[str] = []
+    used_paths: set[str] = set()
     for index, (filename, sysml_text) in enumerate(sysml_models):
-        basename = Path(filename).name
+        relative_path = Path(str(filename or "").replace("\\", "/"))
+        parts = [part for part in relative_path.parts if part not in {"", ".", ".."}]
+        basename = parts[-1] if parts else f"model-{index + 1}.sysml"
         suffix = Path(basename).suffix.lower()
         if suffix not in {".sysml", ".kerml", ".syml"}:
             suffix = ".sysml"
-        temp_path = Path(tmp_dir) / f"{index:04d}_{Path(basename).stem}{suffix}"
+        stem = Path(basename).stem or f"model-{index + 1}"
+        rel_parts = [f"{index:04d}"]
+        if len(parts) > 1:
+            rel_parts.extend(parts[:-1])
+        rel_parts.append(f"{stem}{suffix}")
+        temp_path = Path(tmp_dir).joinpath(*rel_parts)
+        while os.fspath(temp_path) in used_paths:
+            temp_path = temp_path.with_name(f"{temp_path.stem}-{index + 1}{temp_path.suffix}")
+        used_paths.add(os.fspath(temp_path))
+        temp_path.parent.mkdir(parents=True, exist_ok=True)
         temp_path.write_text(sysml_text, encoding="utf-8")
         temp_paths.append(os.fspath(temp_path))
     return basenames, temp_paths

--- a/tests/test_mocked_syside.py
+++ b/tests/test_mocked_syside.py
@@ -206,6 +206,55 @@ def test_convert_sysml_models_to_json_uses_environment_models(mock_syside):
 
 
 @patch("flexo_syside_lib.serde.syside")
+def test_convert_sysml_models_to_json_allows_duplicate_basenames_in_environment(mock_syside):
+    env_model = Mock()
+    env_model.to_environment.return_value = "ENV"
+    env_diags = Mock()
+    env_diags.contains_errors.return_value = False
+
+    main_model = Mock()
+    main_diags = Mock()
+    main_diags.contains_errors.return_value = False
+    main_model.user_docs = [Mock()]
+    locked = Mock()
+    locked.root_node = Mock()
+    context_manager = Mock()
+    context_manager.__enter__ = Mock(return_value=locked)
+    context_manager.__exit__ = Mock(return_value=None)
+    main_model.user_docs[0].lock.return_value = context_manager
+
+    mock_syside.try_load_model.side_effect = [
+        (env_model, env_diags),
+        (main_model, main_diags),
+    ]
+
+    writer = Mock()
+    writer.result = json.dumps(
+        [{"@id": "ns1", "@type": "Namespace", "qualifiedName": "alpha.sysml"}]
+    )
+    options = Mock()
+
+    with patch("flexo_syside_lib.serde.create_json_writer", return_value=writer), patch(
+        "flexo_syside_lib.serde.create_serialization_options", return_value=options
+    ), patch("flexo_syside_lib.serde.syside.serialize"):
+        payload, json_string = convert_sysml_models_textual_to_json(
+            [("workspace/alpha.sysml", "package Alpha;")],
+            environment_models=[
+                ("LibA/root/package.sysml", "library package LibA; end;"),
+                ("LibB/root/package.sysml", "library package LibB; end;"),
+            ],
+        )
+
+    assert isinstance(payload, list)
+    assert json.loads(json_string)[0]["qualifiedName"] == "alpha.sysml"
+    env_call_paths = mock_syside.try_load_model.call_args_list[0].args[0]
+    assert len(env_call_paths) == 2
+    assert env_call_paths[0] != env_call_paths[1]
+    assert env_call_paths[0].endswith("LibA\\root\\package.sysml") or env_call_paths[0].endswith("LibA/root/package.sysml")
+    assert env_call_paths[1].endswith("LibB\\root\\package.sysml") or env_call_paths[1].endswith("LibB/root/package.sysml")
+
+
+@patch("flexo_syside_lib.serde.syside")
 def test_create_json_writer(mock_syside):
     mock_writer_class = Mock()
     mock_writer_instance = Mock()


### PR DESCRIPTION
changed the commit-time SysIDE staging so installed library models keep their relative paths instead of being flattened to basenames in flexo_syside/src/flexo_syside_lib/
  serde.py:86. That makes the server-side environment build behave much closer to Jupyter validation and avoids collisions like multiple installed libraries each containing
  package.sysml, which can surface as unresolved-reference diagnostics and then trip the AssertionError you saw during commit on July 17, 2026.

  I also added a regression test in flexo_syside/tests/test_mocked_syside.py:209 covering duplicate basenames across environment libraries. Verification: python -m pytest
  flexo_syside/tests/test_mocked_syside.py flexo_syside/tests/test_library_sync.py passed with 13 passed.